### PR TITLE
Refactor: Fix syntax issue and add loops in C functions

### DIFF
--- a/src/loops.c
+++ b/src/loops.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+
+int forLoop()
+{
+    for (int i = 0; i < 5; i++)
+    {
+        printf("i = %d\n", i);
+    }
+
+    return 0;
+}
+
+int whileLoop()
+{
+    int i = 0;
+    while (i < 5)
+    {
+        printf("i = %d\n", i);
+        i++;
+    }
+
+    return 0;
+}
+
+int main()
+{
+    
+    forLoop();
+    whileLoop();
+
+    return 0;
+}


### PR DESCRIPTION
- Fixed syntax error in C functions for `forLoop` and `whileLoop`.
- Added loops to demonstrate iteration in `forLoop` and `whileLoop`.
- Updated `main` function to call `forLoop` and `whileLoop` for demonstration.

This commit resolves the syntax issue reported during compilation.